### PR TITLE
prevent check to select node

### DIFF
--- a/src/BIMDataMetaBuildingStructure/StructureTreeNodes/GenericTreeNode.vue
+++ b/src/BIMDataMetaBuildingStructure/StructureTreeNodes/GenericTreeNode.vue
@@ -5,6 +5,7 @@
       :disabled="isDisabled"
       :model-value="isSelected"
       @update:model-value="updateSelection"
+      @mousedown.stop
     />
 
     <slot name="icon"></slot>


### PR DESCRIPTION
Before the change, checking a checkbox selects the node. After, it only changes the checkbox state.